### PR TITLE
Update index.php to define a class on the first post page

### DIFF
--- a/lesson_22/index.php
+++ b/lesson_22/index.php
@@ -15,7 +15,7 @@
 			while( have_posts() ): the_post(); ?>
 				
 				<?php 
-					if($i==0): $column = 12; 
+					if($i==0): $column = 12; $class = '';
 					elseif($i > 0 && $i <= 2): $column = 6; $class = ' second-row-padding';
 					elseif($i > 2): $column = 4; $class = ' third-row-padding';
 					endif;


### PR DESCRIPTION
```Notice: Undefined variable: class in ..\index.php on line 26 Call Stack #TimeMemoryFunctionLocation 10.0014236016{main}( )...\index.php:0 20.0024239120require( '..\wp-blog-header.php' )...\index.php:17 30.282723299648require_once( '..\wp-includes\template-loader.php' )...\wp-blog-header.php:19 40.286023325448include( '..\index.php' )...\template-loader.php:74 ">```

When the first post page is opened the echo is trying to print an undefined class.

Thank you for the amazing series. Even though it's year and a half old, it's still brilliant! 
Can't wait to start the advanced one.